### PR TITLE
fixed navbar display flex that was overwritten by some other style

### DIFF
--- a/src/components/Navbar/Navbar.css
+++ b/src/components/Navbar/Navbar.css
@@ -20,6 +20,14 @@ nav {
     color: #fff;
 font-size: 1.5rem;
 }
+
+#nav-items{
+    display: flex !important;
+    flex-direction: row;
+    align-items: center;
+    justify-content: center;
+}
+
 #nav-items li{
     list-style: none;
     margin: 10px 20px;


### PR DESCRIPTION
issue #196 
before:
![image](https://github.com/rohansx/informatician/assets/110753356/818ff33e-e7b3-4cdc-a619-8d37e109f66f)
after:
![image](https://github.com/rohansx/informatician/assets/110753356/8b4f61af-25ac-4ef7-ad6f-83730e653289)

display: flex was being overwritten. fixed it with an important tag.