### PR TITLE
Updated About Page for Issue #26

### DIFF
--- a/src/components/About/About.css
+++ b/src/components/About/About.css
@@ -24,6 +24,7 @@
   font-size: 32px;
   font-weight: bold;
   margin-bottom: 20px;
+  margin-top: 35px;
 }
 
 .about-description {
@@ -41,6 +42,7 @@
 .book-image {
   max-width: 100%;
   height: auto;
+  padding-bottom: 100px;
 }
 
 .giphy-image {


### PR DESCRIPTION
**Fixed** #246 
Earlier the heading of the About us page was unaligned , now I have fixed it and now it looks fine. attaching updated About us Page Screenshots.

**Screenshots**
In PC/Laptop screens
![image](https://github.com/rohansx/informatician/assets/92742868/75e64bc8-d347-4881-a852-b0f7b98dffaf)

In Surface pro
![image](https://github.com/rohansx/informatician/assets/92742868/0cccd67c-28fd-4e3e-90cb-fa821e2a5d47)


**Additional features**
Earlier the image in the about us page was bit downward , so added padding of 100px.


In case of any update required kindly do let me know.