### PR TITLE
Bug Solved - Two Controls for categories slider

### DIFF
--- a/src/components/Home/CgCards/CgCards.js
+++ b/src/components/Home/CgCards/CgCards.js
@@ -25,6 +25,9 @@ export default function CgCards() {
               1024: { items: 3},
               1500: { items: 4 },
             }}
+            disableButtonsControls
+            autoPlay={true}
+            autoPlayStrategy="default"
           >
             <CardContent
               image={ebk1}


### PR DESCRIPTION
There were 2 controls for categories slider, I improved it to only one 1 control. I also made the categories slider autoplay, the autoplay stops on user hover. Currently it looks as below: 
![Screenshot (24)](https://github.com/rohansx/informatician/assets/71834515/171f000b-d58b-405c-9673-759ce557b722)
I solved it and now it looks as below:
https://drive.google.com/file/d/1r3PIPHLXkqRN0a-Umt-BgbnIw2qny2AX/view?usp=sharing