### PR TITLE
Fixed #426 Hover effect on download app buttons blends play-store and app-store icon

### DIFF
--- a/src/components/About/Download.css
+++ b/src/components/About/Download.css
@@ -52,6 +52,10 @@
   color: palevioletred;
 }
 
+.download .right button:hover > svg{
+  color: palevioletred;
+}
+
 .download .right button .apple {
   font-size: 2rem;
   margin: 0 10px 2px 0;


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #426 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->
The hover effect on download app buttons blends the play-store and app-store icons,It has been fixed with CSS.


## Screenshots

<!-- Add screenshots to preview the changes  -->
before:
![image](https://github.com/rohansx/informatician/assets/123638309/90195dd3-bf3e-447e-b2ab-8606928e2206)
![image](https://github.com/rohansx/informatician/assets/123638309/e03d2695-65c8-435d-a00f-0a1c5f956eda)

after:
![image](https://github.com/rohansx/informatician/assets/123638309/52ab86d6-4e83-4058-97ae-9a3bad54e6f8)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.