### PR TITLE
Feat : Add workflow to assign PR to the author

### DIFF
--- a/.github/workflows/author-assign-pr.yml
+++ b/.github/workflows/author-assign-pr.yml
@@ -1,0 +1,16 @@
+name: 'Author Assign'
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  assign-author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: toshimaru/auto-author-assign@v1.6.2
+        with:
+          repo-token: '${{ secrets.GITHUB_TOKEN }}' 


### PR DESCRIPTION

## Related Issue

Closes #525 

## Description

- The purpose of this workflow is to automatically assign the author of the pull request. It uses the provided GitHub token
(secrets.GITHUB_TOKEN) to perform this action.

- By using this workflow, the author of a pull request will be automatically assigned when the pull request is opened or reopened in the repository.


## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.