### PR TITLE
fixed bug in books page search bar

### DIFF
--- a/src/components/BookList/BookList.css
+++ b/src/components/BookList/BookList.css
@@ -85,7 +85,7 @@ form {
 }
 .searchbar:hover{
   animation: hoverShake 0.15s linear 3;
-  margin-left: 350px;
+  /* margin-left: 350px; */
 }
 #search-button-2 {
   padding: 5px;


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #553 

## Description

While hovering over the search icon on the books page, the search bar was supposed to expand according to the animation set on the icon but it was behaving weirdly. I fixed it by making some changes in the styling of the search icon while hovering over it.

## Screenshots
screenshot

![Screenshot 2023-06-17 132417](https://github.com/rohansx/informatician/assets/77545230/7147c638-a450-48f7-8298-325080067920)

video

https://github.com/rohansx/informatician/assets/77545230/a8eeb153-e3ec-4699-8a93-233205bee9cc


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.