### PR TITLE
Dark mode added to Terms and Cookies pages with minor issues resolved

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -59,9 +59,9 @@ function Body(props) {
         <Route path="/about" element={<About theme={props.theme} />} />
         <Route path="/contact" element={<Contact />} />
         <Route path="/team" element={<Team />} />
-        <Route path="/terms" element={<TermsAndService />} />
+        <Route path="/terms" element={<TermsAndService theme={props.theme}/>} />
         <Route path="/privacy" element={<PrivacyPolicy />} />
-        <Route path="/cookie" element={<CookiePolicy />} />
+        <Route path="/cookie" element={<CookiePolicy theme={props.theme} />} />
         <Route path="/faq" element={<FaqHelp />} />
         <Route path="/join" element={<Join />} />
         <Route path="/develop" element={<Develop />} />

--- a/src/components/Cookie.css
+++ b/src/components/Cookie.css
@@ -1,43 +1,43 @@
 .privacy {
-    padding: 50px 0;
-    background-color: #f8f8f8;
-  }
-  
-  .privacy-container {
-    max-width: 960px;
-    margin: 0 auto;
-    padding: 0 20px;
-  }
-  
-  .privacy-title {
-    font-size: 28px;
-    font-weight: bold;
-    text-align: center;
-    margin: 30px 0px;
-  }
-  
-  .privacy-section {
-    margin-bottom: 40px;
-  }
-  
-  .privacy-section-title {
-    font-size: 24px;
-    font-weight: bold;
-    margin-bottom: 10px;
-  }
-  
-  .privacy-content {
-    margin-top: 10px;
-  }
-  
-  .privacy-content p {
-    margin-bottom: 15px;
-    text-align: justify;
-    text-justify: inter-word;
-  }
-  
-  .contact-email {
-    color: #007bff;
-    text-decoration: none;
-  }
-  
+  padding: 50px 0;
+  background-color: #f8f8f8;
+}
+
+.privacy-container {
+  max-width: 960px;
+  margin: 30px auto;
+  padding: 0 20px;
+}
+
+.privacy-title {
+  font-size: 28px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 30px;
+  padding: 20px;
+}
+
+.privacy-section {
+  margin-bottom: 40px;
+}
+
+.privacy-section-title {
+  font-size: 24px;
+  font-weight: bold;
+  margin-bottom: 10px;
+}
+
+.privacy-content {
+  margin-top: 10px;
+}
+
+.privacy-content p {
+  margin-bottom: 15px;
+  text-align: justify;
+  text-justify: inter-word;
+}
+
+.contact-email {
+  color: #007bff;
+  text-decoration: none;
+}

--- a/src/components/Terms&Service.js
+++ b/src/components/Terms&Service.js
@@ -47,7 +47,7 @@ const TermsAndService = (props) => {
             your jurisdiction.
           </p>
           <p>
-            If you have any questions or concerns about these terms and conditions, please contact us at
+            If you have any questions or concerns about these terms and conditions, please contact us at&nbsp;
             <a href="mailto:informaticianx@gmail.com" className="contact-email">informaticianx@gmail.com</a>.
           </p>
         </div>

--- a/src/components/TermsAndService.css
+++ b/src/components/TermsAndService.css
@@ -1,61 +1,60 @@
 .terms {
-    padding: 50px 0;
-    background-color: #f8f8f8;
-  }
-  
-  .container {
-    max-width: 960px;
-    margin: 30px auto;
-    padding: 0 20px;
-  }
-  
-  .terms-title {
-    font-size: 28px;
-    font-weight: bold;
-    text-align: center;
-    margin-bottom: 30px;
-  }
-  
-  .terms-content {
-    text-align: justify;
-    line-height: 1.5;
-  }
-  
-  .terms-content h3 {
-    font-size: 22px;
-    font-weight: bold;
-    margin: 30px 0 15px;
-  }
-  
-  .terms-content p {
-    margin-bottom: 20px;
-  }
-  
-  .terms-content ul {
-    margin-bottom: 20px;
-    padding-left: 20px;
-  }
-  
-  .terms-content ul li {
-    margin-bottom: 10px;
-    display: flex;
-    align-items: center;
-  }
-  
-  .terms-content ul li .icon {
-    margin-right: 10px;
-  }
-  
-  .terms-content a {
-    color: #007bff;
-    text-decoration: none;
-  }
-  
-  .terms-content a:hover {
-    text-decoration: underline;
-  }
-  
-  .terms-content .contact-email {
-    font-weight: bold;
-  }
-  
+  padding: 50px 0;
+  background-color: #f8f8f8;
+}
+
+.container {
+  max-width: 960px;
+  margin: 30px auto;
+  padding: 0 20px;
+}
+
+.terms-title {
+  font-size: 28px;
+  font-weight: bold;
+  text-align: center;
+  margin-bottom: 30px;
+}
+
+.terms-content {
+  text-align: justify;
+  line-height: 1.5;
+}
+
+.terms-content h3 {
+  font-size: 22px;
+  font-weight: bold;
+  margin: 30px 0 15px;
+}
+
+.terms-content p {
+  margin-bottom: 20px;
+}
+
+.terms-content ul {
+  margin-bottom: 20px;
+  padding-left: 20px;
+}
+
+.terms-content ul li {
+  margin-bottom: 10px;
+  display: flex;
+  align-items: center;
+}
+
+.terms-content ul li .icon {
+  margin-right: 10px;
+}
+
+.terms-content a {
+  color: #007bff;
+  text-decoration: none;
+}
+
+.terms-content a:hover {
+  text-decoration: underline;
+}
+
+.terms-content .contact-email {
+  font-weight: bold;
+}


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

* Closes #575 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The dark mode is now added to Terms and Cookies pages. Also there were alignment issues and typo in the "Cookies" page which is resolved now.
Screenshots added for reference:

## Screenshots

1. Terms and Service Page updated:
<img width="960" alt="Screenshot 2023-06-20 131150" src="https://github.com/rohansx/informatician/assets/113239388/36a46ce9-e3da-405f-85d1-e50d83b806e9">

2. Alignment issue on Cookies page and dark mode updated:
Before:
<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/60414b38-9e85-4f51-9d6e-30fd3833a591">

After:
<img width="960" alt="Screenshot 2023-06-20 131047" src="https://github.com/rohansx/informatician/assets/113239388/ca8ab0bb-3ffe-456b-ac41-7c26e5d28299">

3. Typo 
Before:
(no space before email):
<img width="672" alt="Screenshot 2023-06-20 131130" src="https://github.com/rohansx/informatician/assets/113239388/347a5db0-0a93-423f-9d1e-9d75ef7a73ac">

After:
<img width="661" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/67e87e86-73f8-4329-b12c-e817c82f0ebc">


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.