### PR TITLE
Solved all the dark mode issues - Our Team | Privacy Policy | Books

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -45,22 +45,22 @@ function Body(props) {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/books" element={<BookList theme={props.theme} />} />
-        <Route path="/books/book" element={<SingleBk />} />
-        <Route path="/books/book1" element={<SingleBk1 />} />
-        <Route path="/books/book2" element={<SingleBk2 />} />
-        <Route path="/books/book3" element={<SingleBk3 />} />
-        <Route path="/books/book4" element={<SingleBk4 />} />
-        <Route path="/books/book5" element={<SingleBk5 />} />
-        <Route path="/books/book6" element={<SingleBk6 />} />
-        <Route path="/books/book7" element={<SingleBk7 />} />
-        <Route path="/books/book8" element={<SingleBk8 />} />
-        <Route path="/books/book9" element={<SingleBk9 />} />
+        <Route path="/books/book" element={<SingleBk theme={props.theme} />} />
+        <Route path="/books/book1" element={<SingleBk1 theme={props.theme} />} />
+        <Route path="/books/book2" element={<SingleBk2 theme={props.theme} />} />
+        <Route path="/books/book3" element={<SingleBk3 theme={props.theme} />} />
+        <Route path="/books/book4" element={<SingleBk4 theme={props.theme} />} />
+        <Route path="/books/book5" element={<SingleBk5 theme={props.theme} />} />
+        <Route path="/books/book6" element={<SingleBk6 theme={props.theme} />} />
+        <Route path="/books/book7" element={<SingleBk7 theme={props.theme} />} />
+        <Route path="/books/book8" element={<SingleBk8 theme={props.theme} />} />
+        <Route path="/books/book9" element={<SingleBk9 theme={props.theme} />} />
 
         <Route path="/about" element={<About theme={props.theme} />} />
         <Route path="/contact" element={<Contact />} />
-        <Route path="/team" element={<Team />} />
+        <Route path="/team" element={<Team theme={props.theme} />} />
         <Route path="/terms" element={<TermsAndService theme={props.theme}/>} />
-        <Route path="/privacy" element={<PrivacyPolicy />} />
+        <Route path="/privacy" element={<PrivacyPolicy theme={props.theme} />} />
         <Route path="/cookie" element={<CookiePolicy theme={props.theme} />} />
         <Route path="/faq" element={<FaqHelp />} />
         <Route path="/join" element={<Join />} />

--- a/src/components/Home/SingleBk/SingleBk.js
+++ b/src/components/Home/SingleBk/SingleBk.js
@@ -5,7 +5,7 @@ import ebk1 from "../../../assets/ebooks/ebk1.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,19 +15,19 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   The Perfect Marriage: A Completely Gripping Psychological
                   Suspense
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '', marginLeft: "5px" }}
                       className="pub-link"
                       to="/books/book"
-                      style={{ marginLeft: "5px" }}
                     >
                       <span className="d-flex">
                         <span className="child">Jeneva Rose</span>
@@ -45,7 +45,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book">
+                    <Link className="pub-link" to="/books/book" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -59,7 +59,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -96,11 +96,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book">
+                      <Link className="pub-link" to="/books/book" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
                           <span className="child">Jeneva Rose</span>
                         </span>
@@ -108,11 +108,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">July 13, 2020</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>July 13, 2020</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -172,11 +172,11 @@ export default function SingleBk() {
                           <div style={{ display: "flex", maxWidth: "190px" }}>
                             <div>
                               <FontAwesomeIcon
+                                style={{ color: props.theme === "dark" ? 'white' : '', height: "24px" }}
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk1.js
+++ b/src/components/Home/SingleBk/SingleBk1.js
@@ -5,7 +5,7 @@ import abk1 from "../../../assets/audiobks/abk1.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,16 +15,16 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Audiobook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Audiobook</span>
                 </div>
                 <h1 className="bk-name">The Last Mrs Parrish</h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '',marginLeft: "5px"  }}
                       className="pub-link"
                       to="/books/book1"
-                      style={{ marginLeft: "5px" }}
                     >
                       <span className="d-flex">
                         <span className="child">
@@ -44,7 +44,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book1">
+                    <Link className="pub-link" to="/books/book1" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -58,12 +58,15 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
                         <strong>
                           <em>International Bestseller </em>
+                          </strong>
+                          </p>{" "}
+                      <br />
                           THE INTERNATIONAL BESTSELLER AND DECEMBER PICK FOR
                           REESE WITHERSPOON'S HELLO SUNSHINE BOOK CLUB Featuring
                           a sneak peek at Liv Constantine’s second novel, THE
@@ -72,8 +75,8 @@ export default function SingleBk() {
                           thrilling twist at the end!!" —Reese Witherspoon “Will
                           keep you up. In a ‘can’t put it down’ way. It’s ‘The
                           Talented Mr. Ripley’ with XX chromosomes.”—The Skimm
-                        </strong>
-                      </p>{" "}
+                        
+                      {/* </p>{" "} */}
                       <br />
                       <p>
                         A REESE WITHERSPOON HELLO SUNSHINE BOOK CLUB PICK WITH
@@ -116,11 +119,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book1">
+                      <Link className="pub-link" to="/books/book1" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
                           <span className="child">
                             Lynne Constantine and Valerie Constantine
@@ -130,11 +133,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2017</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2017</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -195,10 +198,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ color: props.theme === "dark" ? 'white' : '',height: "24px" }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk2.js
+++ b/src/components/Home/SingleBk/SingleBk2.js
@@ -5,7 +5,7 @@ import abk2 from "../../../assets/audiobks/abk2.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,18 +15,18 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Audiobook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Audiobook</span>
                 </div>
                 <h1 className="bk-name">
-                  The Guest List:YOU'D KILL TO BE ON IT
+                  The Guest List: YOU'D KILL TO BE ON IT
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
                       className="pub-link"
                       to="/books/id"
-                      style={{ marginLeft: "5px" }}
+                      style={{ marginLeft: "5px",  color: props.theme === "dark" ? 'white' : ''  }}
                     >
                       <span className="d-flex">
                         <span className="child">Lucy Foley</span>
@@ -44,7 +44,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/id">
+                    <Link className="pub-link" to="/books/id" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -58,7 +58,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 style={{ color: props.theme === "dark" ? 'white' : '' }} className="abt-bk">About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -96,27 +96,27 @@ export default function SingleBk() {
                     </div>
                   </div>
                 </div>
-                <div style={{ marginBottom: "40px" }}>
+                <div style={{ marginBottom: "40px" }} >
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
                       <Link className="pub-link" to="/books/id">
                         <span className="d-flex">
-                          <span className="child">Lucy Foley</span>
+                          <span className="child" style={{ color: props.theme === "dark" ? 'white' : '' }}>Lucy Foley</span>
                         </span>
                       </Link>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -176,11 +176,11 @@ export default function SingleBk() {
                           <div style={{ display: "flex", maxWidth: "190px" }}>
                             <div>
                               <FontAwesomeIcon
+                              style={{ color: props.theme === "dark" ? 'white' : '', height: "24px" }}
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk3.js
+++ b/src/components/Home/SingleBk/SingleBk3.js
@@ -5,7 +5,7 @@ import abk3 from "../../../assets/audiobks/abk3.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,16 +15,17 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Audiobook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Audiobook</span>
                 </div>
                 <h1 className="bk-name">The Subtle Art of Not Giving a F*ck</h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '', marginLeft: "5px" }}
                       className="pub-link"
                       to="/books/book3"
-                      style={{ marginLeft: "5px" }}
+
                     >
                       <span className="d-flex">
                         <span className="child">Mark Manson</span>
@@ -42,9 +43,9 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book3">
+                    <Link className="pub-link" to="/books/book3" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
-                        <span className="child">(1,103 ratings)</span>
+                        <span className="child" >(1,103 ratings)</span>
                       </span>
                     </Link>
                   </p>
@@ -56,7 +57,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -89,23 +90,23 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book3">
+                      <Link className="pub-link" to="/books/book3" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
-                          <span className="child">Mark Manson</span>
+                          <span className="child" >Mark Manson</span>
                         </span>
                       </Link>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -165,11 +166,11 @@ export default function SingleBk() {
                           <div style={{ display: "flex", maxWidth: "190px" }}>
                             <div>
                               <FontAwesomeIcon
+                              style={{ color: props.theme === "dark" ? 'white' : '', height: "24px" }}
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk4.js
+++ b/src/components/Home/SingleBk/SingleBk4.js
@@ -5,7 +5,7 @@ import abk4 from "../../../assets/audiobks/abk4.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,19 +15,19 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Audiobook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Audiobook</span>
                 </div>
                 <h1 className="bk-name">
                   Building a StoryBrand: Clarify Your Message So Customers Will
                   Listen
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '', marginLeft: "5px" }}
                       className="pub-link"
                       to="/books/book4"
-                      style={{ marginLeft: "5px" }}
                     >
                       <span className="d-flex">
                         <span className="child">
@@ -47,7 +47,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book4">
+                    <Link className="pub-link" to="/books/book4" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -61,7 +61,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -104,11 +104,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book4">
+                      <Link className="pub-link" to="/books/book4" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
                           <span className="child">
                             HarperCollins Leadership Audio
@@ -118,11 +118,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -183,10 +183,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px", color: props.theme === "dark" ? 'white' : '' }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk5.js
+++ b/src/components/Home/SingleBk/SingleBk5.js
@@ -5,7 +5,7 @@ import ebk2 from "../../../assets/ebooks/ebk2.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,18 +15,18 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   An Ugly Truth: Inside Facebook's Battle for Domination
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
                       className="pub-link"
                       to="/books/book5"
-                      style={{ marginLeft: "5px" }}
+                      style={{ marginLeft: "5px", color: props.theme === "dark" ? 'white' : '' }}
                     >
                       <span className="d-flex">
                         <span className="child">
@@ -47,7 +47,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book5">
+                    <Link className="pub-link" to="/books/book5" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -61,7 +61,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -102,11 +102,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book5">
+                      <Link className="pub-link" to="/books/book5" style={{ color: props.theme === "dark" ? 'white' : '' }}> 
                         <span className="d-flex">
                           <span className="child">
                             {" "}
@@ -117,11 +117,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -182,10 +182,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px",color: props.theme === "dark" ? 'white' : '' }} 
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk6.js
+++ b/src/components/Home/SingleBk/SingleBk6.js
@@ -5,7 +5,7 @@ import ebk3 from "../../../assets/ebooks/ebk3.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,19 +15,19 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   Never Split the Difference: Negotiating As If Your Life
                   Depended On
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '', marginLeft: "5px" }}
                       className="pub-link"
                       to="/books/book6"
-                      style={{ marginLeft: "5px" }}
                     >
                       <span className="d-flex">
                         <span className="child">Chris Voss,Tahl Raz </span>
@@ -45,7 +45,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book6">
+                    <Link className="pub-link" to="/books/book6" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -59,7 +59,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 style={{ color: props.theme === "dark" ? 'white' : '' }} className="abt-bk">About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -107,11 +107,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book6">
+                      <Link className="pub-link" to="/books/book6" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
                           <span className="child">Chris Voss,Tahl Raz</span>
                         </span>
@@ -119,11 +119,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -184,10 +184,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px", color: props.theme === "dark" ? 'white' : '' }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk7.js
+++ b/src/components/Home/SingleBk/SingleBk7.js
@@ -5,7 +5,7 @@ import ebk4 from "../../../assets/ebooks/ebk4.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,18 +15,18 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type"  style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   Everything Is F*cked: A Book About Hope
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
+                      style={{ color: props.theme === "dark" ? 'white' : '', marginLeft: "5px" }}
                       className="pub-link"
                       to="/books/book7"
-                      style={{ marginLeft: "5px" }}
                     >
                       <span className="d-flex">
                         <span className="child">Mark Manson</span>
@@ -44,7 +44,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book7">
+                    <Link className="pub-link" to="/books/book7" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -58,7 +58,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 className="abt-bk" style={{ color: props.theme === "dark" ? 'white' : '' }}>About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -106,23 +106,23 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
                       <Link className="pub-link" to="/books/book7">
                         <span className="d-flex">
-                          <span className="child">Mark Manson</span>
+                          <span className="child" style={{ color: props.theme === "dark" ? 'white' : '' }}>Mark Manson</span>
                         </span>
                       </Link>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -183,10 +183,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px", color: props.theme === "dark" ? 'white' : ''  }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk8.js
+++ b/src/components/Home/SingleBk/SingleBk8.js
@@ -5,7 +5,7 @@ import ebk5 from "../../../assets/ebooks/ebk5.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,19 +15,19 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   The Intelligent Investor: The Definitive Book on Value
                   Investing
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
                       className="pub-link"
                       to="/books/book8"
-                      style={{ marginLeft: "5px" }}
+                      style={{ marginLeft: "5px",  color: props.theme === "dark" ? 'white' : '' }}
                     >
                       <span className="d-flex">
                         <span className="child">Benjamin Graham</span>
@@ -45,7 +45,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book8">
+                    <Link className="pub-link" to="/books/book8" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -59,7 +59,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 style={{ color: props.theme === "dark" ? 'white' : '' }} className="abt-bk">About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -97,23 +97,23 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
                       <Link className="pub-link" to="/books/book8">
                         <span className="d-flex">
-                          <span className="child">Benjamin Graham</span>
+                          <span className="child" style={{ color: props.theme === "dark" ? 'white' : '' }}>Benjamin Graham</span>
                         </span>
                       </Link>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -174,10 +174,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px", color: props.theme === "dark" ? 'white' : '' }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div style={{ color: props.theme === "dark" ? 'white' : '' }} className="label">Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Home/SingleBk/SingleBk9.js
+++ b/src/components/Home/SingleBk/SingleBk9.js
@@ -5,7 +5,7 @@ import ebk6 from "../../../assets/ebooks/ebk6.webp";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 
-export default function SingleBk() {
+export default function SingleBk(props) {
   return (
     <div className="single-view">
       <div className="container-fluid">
@@ -15,18 +15,18 @@ export default function SingleBk() {
               <div className="space hide"></div>
               <div className="left-wrapper-content">
                 <div className="first-section">
-                  <span className="first-type">Ebook</span>
+                  <span className="first-type" style={{ color: props.theme === "dark" ? 'white' : '' }}>Ebook</span>
                 </div>
                 <h1 className="bk-name">
                   Vanderbilt: The Rise and Fall of an American Dynasty
                 </h1>
                 <div className="publication">
-                  <p className="pub-name">
+                  <p className="pub-name" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                     By
                     <Link
                       className="pub-link"
                       to="/books/book9"
-                      style={{ marginLeft: "5px" }}
+                      style={{ marginLeft: "5px", color: props.theme === "dark" ? 'white' : '' }}
                     >
                       <span className="d-flex">
                         <span className="child">
@@ -46,7 +46,7 @@ export default function SingleBk() {
                     />
                   </div>
                   <p className="rating-count">
-                    <Link className="pub-link" to="/books/book9">
+                    <Link className="pub-link" to="/books/book9" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                       <span className="d-flex">
                         <span className="child">(1,103 ratings)</span>
                       </span>
@@ -60,7 +60,7 @@ export default function SingleBk() {
                   ></div>
                 </span>
                 <div style={{ marginBottom: "56px" }}>
-                  <h2 className="abt-bk">About this Book</h2>
+                  <h2 style={{ color: props.theme === "dark" ? 'white' : '' }} className="abt-bk">About this Book</h2>
                   <div style={{ marginTop: "8px", fontSize: "1rem" }}>
                     <div className="theory">
                       <p>
@@ -109,11 +109,11 @@ export default function SingleBk() {
                   <div className="bk-desc">
                     <div className="lang">
                       <span className="first-lang">Language</span>
-                      <span className="second-lang">English</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>English</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">Publisher</span>
-                      <Link className="pub-link" to="/books/book9">
+                      <Link className="pub-link" to="/books/book9" style={{ color: props.theme === "dark" ? 'white' : '' }}>
                         <span className="d-flex">
                           <span className="child">
                             Anderson Cooper, Katherine Howe
@@ -123,11 +123,11 @@ export default function SingleBk() {
                     </div>
                     <div className="lang">
                       <span className="first-lang">Release Date</span>
-                      <span className="second-lang">Oct 17, 2001</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>Oct 17, 2001</span>
                     </div>
                     <div className="lang">
                       <span className="first-lang">ISBN</span>
-                      <span className="second-lang">9780718074326</span>
+                      <span className="second-lang" style={{ color: props.theme === "dark" ? 'white' : '' }}>9780718074326</span>
                     </div>
                   </div>
                 </div>
@@ -188,10 +188,10 @@ export default function SingleBk() {
                             <div>
                               <FontAwesomeIcon
                                 icon={faBookmark}
-                                style={{ height: "24px" }}
+                                style={{ height: "24px", color: props.theme === "dark" ? 'white' : ''  }}
                               />
                             </div>
-                            <div className="label">Save for later</div>
+                            <div className="label" style={{ color: props.theme === "dark" ? 'white' : '' }}>Save for later</div>
                           </div>
                         </button>
                       </li>

--- a/src/components/Team/ContCard.js
+++ b/src/components/Team/ContCard.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import './Contributor.css';
+
 const ContCard = (props) => {
   var x = '';
-  const { image, title, commits, profile} = props;
+  const { image, title, commits, profile } = props;
   if (commits === 1) {
     var x = 'commit';
   } else {
@@ -16,16 +17,22 @@ const ContCard = (props) => {
   return (
     <>
       <div
-        className='card'>
-        <img className='profile' src={`https://images.weserv.nl/?output=webp&url=${image}`} alt={title} />
+        className='card' style={{ border: props.theme === "dark" ? '2px solid white' : '2px solid black' }}>
+        <img className='profile' src={`https://images.weserv.nl/?output=webp&url=${image}`} alt={title} 
+        style={{ border: props.theme === "dark" ? '2px solid white' : '2px solid black' }}
+        />
         <div className='content'>
-          <h1 className='text'>{title}</h1>
-          <p>
+          <h1 className='text' style={{ color: props.theme === "dark" ? 'white' : '' }}>{title}</h1>
+          <p style={{ color: props.theme === "dark" ? 'white' : '' }}>
             {commits} {x}
           </p>
         </div>
         <div>
-          <button className='view_button' onClick={() => openContributorProfile(profile)} >View</button>
+          <button className='view_button' onClick={() => openContributorProfile(profile)} 
+          style={{ border: props.theme === "dark" ? '2px solid white' : '2px solid black' , 
+          color: props.theme === "dark" ? 'white' : ''
+        }}
+          >View</button>
         </div>
       </div>
     </>

--- a/src/components/Team/Contributor.css
+++ b/src/components/Team/Contributor.css
@@ -3,7 +3,7 @@
 
 .profile {
   border-radius: 50%;
-  border: 2px solid black;
+  /* border: 2px solid black; */
   height: 230px;
     width: 230px;
   margin-bottom: 10px;
@@ -25,7 +25,7 @@
   padding: 15px;
   cursor: pointer;
   background-color: transparent;
-  border: 2px solid black;
+  /* border: 2px solid black; */
   height: 20rem;
 }
 

--- a/src/components/Team/Contributor.js
+++ b/src/components/Team/Contributor.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import ContCard from './ContCard';
 import './Contributor.css';
 
-const Contributors = () => {
+const Contributors = (props) => {
     const [contributors, setContributors] = useState([]);
 
     const fetchContributors = async () => {
@@ -39,6 +39,7 @@ const Contributors = () => {
                         title={contributor.login}
                         commits={contributor.contributions}
                         profile={contributor.html_url} 
+                        theme={props.theme}
                     />
                 ))}
             </div>

--- a/src/components/Team/Team.js
+++ b/src/components/Team/Team.js
@@ -60,7 +60,7 @@ const Team = (props) => {
         </div>
 
       </div>
-      <Contributor />
+      <Contributor theme={props.theme} />
     </div>
 
   );


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

* Closes #577 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

Added the dark mode implementation to the pages - Our team, privacy policy and individual book pages.
The details page of all the 10 books were changed as there were many bugs in the dark mode implementation and styling.
Adding the screenshots for reference:

## Screenshots

1. Our Team:

Before:
<img width="959" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/51e87a80-7fe1-4d3e-87cc-da31165b4e7b">


After: 
<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/563a346c-c4aa-4723-9cc9-b581e289bc8b">

2. Privacy Page:

Before:
<img width="959" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/4599eaa3-860d-411f-a254-4c9fd7240bb1">

After:
<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/132a1afb-69e2-462b-941f-eab08d36682c">

3. Book Details: (All the 10 books - 10 files)

Before:
<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/d41a4a4a-9c6c-4d4f-bcf1-454fa6b72a21">

After:
<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/e1963c06-b9bb-43fc-abff-72a1e9483a50">


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.