### PR TITLE
Added dark mode to FAQs

### DIFF
--- a/src/components/Body.js
+++ b/src/components/Body.js
@@ -62,7 +62,7 @@ function Body(props) {
         <Route path="/terms" element={<TermsAndService theme={props.theme}/>} />
         <Route path="/privacy" element={<PrivacyPolicy theme={props.theme} />} />
         <Route path="/cookie" element={<CookiePolicy theme={props.theme} />} />
-        <Route path="/faq" element={<FaqHelp />} />
+        <Route path="/faq" element={<FaqHelp theme={props.theme} />} />
         <Route path="/join" element={<Join />} />
         <Route path="/develop" element={<Develop />} />
         <Route path="/addBooks" element={<AddBooks />} />

--- a/src/components/faq.js
+++ b/src/components/faq.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import "./faq.css";
 import helpImage from "../assets/help.png";
 
-const AccordionItem = ({ title, content }) => {
+const AccordionItem = ({ title, content, theme }) => {
   const [expanded, setExpanded] = useState(false);
 
   const toggleAccordion = () => {
@@ -10,7 +10,9 @@ const AccordionItem = ({ title, content }) => {
   };
 
   return (
-    <div className={`accordion-item ${expanded ? 'expanded' : ''}`}>
+    <div className={`accordion-item ${expanded ? 'expanded' : ''}`}
+    style={{backgroundColor: theme === 'dark' ? 'black' : 'white'}}
+    >
       <button
         onClick={toggleAccordion}
         aria-expanded={expanded ? 'true' : 'false'}
@@ -19,13 +21,13 @@ const AccordionItem = ({ title, content }) => {
         <span className="icon" aria-hidden="true"></span>
       </button>
       <div className="accordion-content">
-        <p>{content}</p>
+        <p style={{color: theme === 'dark' ? 'white' : 'black'}}>{content}</p>
       </div>
     </div>
   );
 };
 
-const FaqHelp = () => {
+const FaqHelp = (props) => {
   return (
 
     <div className="faq-help">
@@ -43,22 +45,26 @@ const FaqHelp = () => {
             content="A: One can start by setting aside dedicated time for reading
             each day. Creating a comfortable reading environment and choosing
             books that genuinely interest you can also help."
+            theme={props.theme}
           />
           <AccordionItem
             title=" Q: What are some common reasons why people abandon books midway?"
             content=" A: Some reasons include a lack of interest in the content or
             finding it difficult to connect with the writing style. However,
             there are many other books to choose from."
+            theme={props.theme}
           />
            <AccordionItem
             title=" Q:What are the benefits of reading regularly?"
             content=" A: Reading regularly has numerous benefits : improved cognitive function, increased knowledge, and enhanced focus & concentration.
             It reduces stress and promotes relaxation by immersing you in a different world or story.
             Reading improves ones vocabulary, language skills, and writing abilities, making one an effective communicator."
+            theme={props.theme}
           />
            <AccordionItem
             title=" Q:What are some strategies for staying motivated to read?"
             content=" A: To stay motivated to read, it can be helpful to set reading goals and establish a regular reading routine.Additionally, having a consistent reading routine helps to make reading a habit and ensures one to set aside dedicated time for it."
+            theme={props.theme}
           />
         </div>
       </div>


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

* Closes #587 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The dark mode feature was not applied to the FAQs. Resolved this styling mismatch.

## Screenshots

![image](https://github.com/rohansx/informatician/assets/113239388/b5e26c0d-ea02-4af6-abdb-83961882a96b)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.