### PR TITLE
Resolved dark mode issue on contact page

### DIFF
--- a/src/components/Contactus.css
+++ b/src/components/Contactus.css
@@ -146,7 +146,6 @@ p {
   padding-top: 50px;
   padding-left: 50px;
   padding-bottom: 50px;
-  background: white;
 }
 
 .contact-text {


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

* Closes #656 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

The dark mode was not applicable to the contact page. Resolved the same by updating CSS styles.

## Screenshots

<img width="960" alt="image" src="https://github.com/rohansx/informatician/assets/113239388/c2ec2e0b-486b-4dc7-bfdd-52f6ea22df9e">

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.