### PR TITLE
[FEAT]: MAKE SOCIAL ANCHORS ACCESSIBLE ON FOOTER ✨

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -114,6 +114,9 @@ class Footer extends React.Component {
             <div className="flex mt-4 space-x-6 sm:justify-center md:mt-0">
               <Link
                 to="#"
+                aria-label="Follow us on Facebook"
+                title="Facebook (External Link)"
+                rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white hover:scale-125 "
               >
                 <BsFacebook />
@@ -121,6 +124,9 @@ class Footer extends React.Component {
               </Link>
               <Link
                 to="#"
+                aria-label="Follow us on Instagram"
+                title="Instagram (External Link)"
+                rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white hover:scale-125 "
               >
                 <BsInstagram />
@@ -128,12 +134,18 @@ class Footer extends React.Component {
               </Link>
               <Link
                 to="#"
+                aria-label="Follow us on Twitter"
+                title="Twitter (External Link)"
+                rel="noopener noreferrer"
                 className="text-gray-400 hover:text-white hover:scale-125 "
               >
                 <BsTwitter />
                 <span className="sr-only">Twitter page</span>
               </Link>
               <a
+                aria-label="Follow us on Github"
+                title="Github (External Link)"
+                rel="noopener noreferrer"
                 to="https://github.com/rohansx/informatician"
                 className="text-gray-400 hover:text-white hover:scale-125 "
               >


### PR DESCRIPTION
## Related Issue

Closes #800 

## Description

- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Improved `title` attribute's data, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Screenshots
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.