### PR TITLE
feat: add slider to quote section

### DIFF
--- a/src/components/BookList/BookList.css
+++ b/src/components/BookList/BookList.css
@@ -139,6 +139,7 @@ form {
 
 .book_card-container {
   display: flex;
+  height: auto;
   overflow-x: scroll;
   scroll-behavior: smooth;
   scroll-snap-type: x mandatory;
@@ -146,7 +147,7 @@ form {
   padding-bottom: 50px;
 }
 
-.book_card {
+/* .book_card {
   box-shadow: rgba(69, 68, 68, 0.283) 0px 25px 20px -20px;
   flex: 0 0 300px;
   margin-right: 25px;
@@ -155,7 +156,7 @@ form {
   padding: 20px;
   transition: 1s ease;
   
-}
+} */
 .card:hover {
   box-shadow: rgba(15, 27, 188, 0.551) 0px 1px 2px, rgba(44, 21, 158, 0.589) 0px 2px 4px,
     rgba(15, 57, 183, 0.379) 0px 4px 8px, rgba(35, 6, 149, 0.582) 0px 8px 16px,
@@ -163,10 +164,10 @@ form {
   
 
 }
-.book_card:hover {
+/* .book_card:hover {
   box-shadow: rgba(92, 91, 91, 0.601) 0px 20px 20px 0px;
   transform: translateY(-20px);
-}
+} */
 .book_card img {
  
   box-shadow: rgba(67, 66, 66, 0.4) 0px 2px 4px,
@@ -174,11 +175,12 @@ form {
   object-fit: cover;
   margin-bottom: 10px;
 }
-.book_quote_img{
-  max-width: 100px; /* Adjust the size as needed */
-  height: 100px; /* Adjust the size as needed */
+/* .book_quote_img{
+  max-width: 100px; 
+  height: 100px; 
   border-radius: 50%;
-}
+  object-fit: cover;
+} */
 .book_card p {
   margin-top: 5px;
   text-align: center;
@@ -260,3 +262,50 @@ form {
     flex: 0 0 350px;
   }
 }
+
+.slide .swiper {
+  width: 100%;
+  height: 100%;
+  margin-bottom: 50px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.slide .swiper-slide {
+  text-align: center;
+  height: auto;
+  background: #eff6ff;
+  border-radius: 10px;
+  padding: 20px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  box-shadow: rgba(69, 68, 68, 0.283) 0px 25px 20px -20px;
+  margin-bottom: 50px;
+  transition: 1s ease;
+  cursor: pointer;
+}
+
+.swiper-slide {
+  margin-bottom: 40px;
+  border: none !important;
+}
+
+.swiper-slide:hover {
+  box-shadow: none !important;
+  transform: none !important;
+
+}
+.slide .swiper-slide img {
+  display: block;
+  max-width: 100px;
+  height: 100px;
+  object-fit: cover;
+  border-radius: 50%;
+  box-shadow: 1px 2px 8px 3px lightgray, 0px 4px 10px rgba(0, 0, 0, 0.1);
+}
+.slide .swiper-pagination-bullet-active {
+  background: #6e7ebc;
+  margin-top: 60px;
+}
+

--- a/src/components/BookList/BookList.js
+++ b/src/components/BookList/BookList.js
@@ -4,6 +4,14 @@ import ScrollToTopButton from "../../components/ScrollButton/ScrollButton";
 // import Card from "../Card";
 import { searchBooks } from "../../utils/searchBooks";
 
+// Import Swiper React components
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+// Import Swiper styles
+import 'swiper/css';
+import 'swiper/css/pagination';
+import SwiperCore,{ Autoplay, Pagination, Navigation } from "swiper";
+
 export default function BookList(props) {
   const [books, setBooks] = useState([]);
   const [bookName, setBookName] = useState("");
@@ -38,7 +46,7 @@ export default function BookList(props) {
 
   }
 
-  useEffect(() => {
+/*   useEffect(() => {
     const cardContainer = cardContainerRef.current;
     cardWidthRef.current = cardContainer.offsetWidth / 4; // Divide by the number of cards to scroll at once
 
@@ -64,7 +72,7 @@ export default function BookList(props) {
 
     // Clear the interval when the component is unmounted
     return () => clearInterval(intervalId);
-  }, []);
+  }, []); */
 
   function toggleCategories() {
     const bookListContainer = document.querySelector(".book-list-container");
@@ -218,89 +226,102 @@ export default function BookList(props) {
       <h3 id="sub-head">Quotes</h3>
 
         <div className="carousel">
-          <div className="book_card-container" ref={cardContainerRef}>
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="https://lit216.pbworks.com/f/1363869393/stephen%20king.jpg" alt="Stephen King" />
-              <h4>- Stephen King</h4>
-                <p>"If you don't have time to read, you don't have the time to write. Simple as that."</p>
-                
-              </div>
-            </div>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" style={{width:'150px'}} src="https://upload.wikimedia.org/wikipedia/en/c/c9/Madeleine_lengle.jpg" alt="Madeleine L'Engle" />
-              <h4>- Madeleine L'Engle</h4>
-                <p>"You have to write the book that wants to be written & if the book will be too difficult for grown-ups, then you write it for children."</p>
-                
-              </div>
-              
-            </div>
+          <Swiper 
+            slidesPerView={3}
+            spaceBetween={25}
+            loop={true}
+            autoplay={true}
+            pagination={{clickable: true,}}
+            modules={[Pagination, Navigation, Autoplay]}
+            className="mySwiper slide">
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="http://laurencecoupe.co.uk/wp-content/uploads/2018/01/kerouac-picture.jpg" alt="Jack Kerouac" />
-              <h4>- Jack Kerouac</h4>
-                <p>"One day I will find the right words, and they will be simple."</p>
-                
-              </div>
-             
-            </div>
+            <div className="book_card-container" ref={cardContainerRef}>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" style={{width:'150px'}}  src="https://media.newyorker.com/photos/59096d586552fa0be682ff3d/master/w_1920,c_limit/Brody-Saul-Bellow-Film-Critic.jpg" alt="Saul Bellow" />
-              <h4>- Saul Bellow</h4>
-                <p>"You never have to change anything you got up in the middle of the night to write."</p>
-                
-              </div>
-             
-            </div>
+              <SwiperSlide>
+                <div className="book_card">
+                    <div className="book_card-content">
+                      <img loading='lazy' className="book_quote_img" src="https://lit216.pbworks.com/f/1363869393/stephen%20king.jpg" alt="Stephen King" />
+                      <h4>- Stephen King</h4>
+                      <p>"If you don't have time to read, you don't have the time to write. Simple as that."</p> 
+                    </div>
+                  </div>
+              </SwiperSlide>
+        
+              <SwiperSlide>
+                <div className="book_card">
+                    <div className="book_card-content">
+                      <img loading='lazy' className="book_quote_img" src="http://laurencecoupe.co.uk/wp-content/uploads/2018/01/kerouac-picture.jpg" alt="Jack Kerouac" />
+                      <h4>- Jack Kerouac</h4>
+                        <p>"One day I will find the right words, and they will be simple."</p>
+                    </div>
+                </div>
+              </SwiperSlide>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="https://images2.minutemediacdn.com/image/upload/c_fill,w_1080,ar_16:9,f_auto,q_auto,g_auto/shape%2Fcover%2Fsport%2Fgettyimages-2665140-a1c77ccabe8660fb5123c8b6c5741316.jpg" alt="Aldous Huxley" />
-              <h4>- Aldous Huxley</h4>
-                <p>"Words can be like X-rays if you use them properly they'll go through anything. You read and you're pierced."</p>
-                
-              </div>
-              
-            </div>
+              <SwiperSlide> 
+                <div className="book_card">
+                  <div className="book_card-content">
+                    <img loading='lazy' className="book_quote_img" style={{width:'150px'}}  src="https://media.newyorker.com/photos/59096d586552fa0be682ff3d/master/w_1920,c_limit/Brody-Saul-Bellow-Film-Critic.jpg" alt="Saul Bellow" />
+                    <h4>- Saul Bellow</h4>
+                    <p>"You never have to change anything you got up in the middle of the night to write."</p>
+                  </div>
+                </div>
+              </SwiperSlide>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="https://media.npr.org/assets/img/2015/03/13/ap070308060493-67009388c842c192821be288e72bbc06977b72ce-s400-c85.webp" alt="Anne Frank" />
-              <h4>- Anne Frank</h4>
-                <p>"I can shake off everything as I write; my sorrows disappear, my courage is reborn."</p>
-               
-              </div>
-             
-            </div>
+              <SwiperSlide>
+                <div className="book_card">
+                  <div className="book_card-content">
+                    <img loading='lazy' className="book_quote_img" src="https://images2.minutemediacdn.com/image/upload/c_fill,w_1080,ar_16:9,f_auto,q_auto,g_auto/shape%2Fcover%2Fsport%2Fgettyimages-2665140-a1c77ccabe8660fb5123c8b6c5741316.jpg" alt="Aldous Huxley" />
+                    <h4>- Aldous Huxley</h4>
+                      <p>"Words can be like X-rays if you use them properly they'll go through anything. You read and you're pierced."</p>
+                  </div>
+                </div>
+              </SwiperSlide>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="https://ychef.files.bbci.co.uk/1600x900/p09pxt8c.webp" alt="Sylvia Plath" />
-              <h4>- Sylvia Plath</h4>
-                <p>"Let me live, love, and say it well in good sentences."</p>
-                
-              </div>
-             
-            </div>
+              <SwiperSlide>
+                <div className="book_card">
+                  <div className="book_card-content">
+                    <img loading='lazy' className="book_quote_img" src="https://media.npr.org/assets/img/2015/03/13/ap070308060493-67009388c842c192821be288e72bbc06977b72ce-s400-c85.webp" alt="Anne Frank" />
+                    <h4>- Anne Frank</h4>
+                      <p>"I can shake off everything as I write; my sorrows disappear, my courage is reborn."</p>
+                  </div>
+                </div>
+              </SwiperSlide>
 
-            <div className="book_card">
-              <div className="book_card-content">
-              <img loading='lazy' className="book_quote_img" src="https://www.theparisreview.org/il/c625e7c0b9/large/JohnSteinbeck-thumb.jpg" alt="John Steinbeck" />
-              <h4>- John Steinbeck</h4>
-                <p>"Ideas are like rabbits. You get a couple and learn how to handle them, and pretty soon you have a dozen."</p>
-                
-              </div>
-            </div>
+              <SwiperSlide> 
+                <div className="book_card">
+                  <div className="book_card-content">
+                    <img loading='lazy' className="book_quote_img" src="https://ychef.files.bbci.co.uk/1600x900/p09pxt8c.webp" alt="Sylvia Plath" />
+                    <h4>- Sylvia Plath</h4>
+                      <p>"Let me live, love, and say it well in good sentences."</p>       
+                  </div>          
+                </div>
+            </SwiperSlide>
 
-          
+              <SwiperSlide>
+                <div className="book_card">
+                  <div className="book_card-content">
+                    <img loading='lazy' className="book_quote_img" src="https://www.theparisreview.org/il/c625e7c0b9/large/JohnSteinbeck-thumb.jpg" alt="John Steinbeck" />
+                    <h4>- John Steinbeck</h4>
+                      <p>"Ideas are like rabbits. You get a couple and learn how to handle them, and pretty soon you have a dozen."</p>                
+                  </div>           
+                </div>
+              </SwiperSlide>
+
+                  <SwiperSlide>
+                    <div className="book_card">
+                      <div className="book_card-content">
+                        <img loading='lazy' className="book_quote_img" style={{width:'150px'}} src="https://upload.wikimedia.org/wikipedia/en/c/c9/Madeleine_lengle.jpg" alt="Madeleine L'Engle" />
+                        <h4>- Madeleine L'Engle</h4>
+                          <p>"You have to write the book that wants to be written & if the book will be too difficult for grown-ups, then you write it for children."</p>             
+                      </div>
+                    </div>
+                </SwiperSlide>
           </div>
-        </div>
+        </Swiper>
+            
       </div>
+    </div>
 
       {/* </div> */}
       <ScrollToTopButton />


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #751 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description

I have added a infinite loop slider to the quote section and fixed the last quote card's visibility which was not fully visible.

## Files modified
- `src/components/BookList/BookList.css`
- `src/components/BookList/BookList.js`

## Screenshots

### Before this PR

![image](https://github.com/rohansx/informatician/assets/130365071/1acd62b1-37c6-4d61-bd6b-680cf49b0d57)

### After this PR

[Informatician.webm](https://github.com/rohansx/informatician/assets/130365071/ffc4f781-7ef4-4c8d-a566-b8a7a4d37b74)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.

Please review this PR 
Thanks