### PR TITLE
Added text color to the FAQ section in light mode  issue-843

### DIFF
--- a/src/components/FAQ/faq.css
+++ b/src/components/FAQ/faq.css
@@ -24,8 +24,7 @@
   margin-bottom: 10px;
 }
 
-
-.help-section{
+.help-section {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -67,14 +66,12 @@
   text-align: left;
 }
 
-
 .faq-help {
   padding: 50px 50px; /* Add margin from left and right */
   text-align: center;
 }
 
-
-@import url('https://fonts.googleapis.com/css?family=Hind:300,400&display=swap');
+@import url("https://fonts.googleapis.com/css?family=Hind:300,400&display=swap");
 
 .faqcontainer {
   margin: 0 auto;
@@ -107,7 +104,7 @@
   padding: 5px;
 }
 
-.accordion .accordion-item button[aria-expanded='true'] {
+.accordion .accordion-item button[aria-expanded="true"] {
   border-bottom: 1px solid #03b5d2;
 }
 
@@ -155,7 +152,7 @@
 .accordion button .icon::before {
   display: block;
   position: absolute;
-  content: '';
+  content: "";
   top: 9px;
   left: 5px;
   width: 10px;
@@ -166,7 +163,7 @@
 .accordion button .icon::after {
   display: block;
   position: absolute;
-  content: '';
+  content: "";
   top: 5px;
   left: 9px;
   width: 2px;
@@ -174,15 +171,15 @@
   background: currentColor;
 }
 
-.accordion button[aria-expanded='true'] {
+.accordion button[aria-expanded="true"] {
   color: #03b5d2;
 }
 
-.accordion button[aria-expanded='true'] .icon::after {
+.accordion button[aria-expanded="true"] .icon::after {
   width: 0;
 }
 
-.accordion button[aria-expanded='true'] + .accordion-content {
+.accordion button[aria-expanded="true"] + .accordion-content {
   opacity: 1;
   max-height: 9em;
   transition: all 200ms linear;
@@ -225,4 +222,7 @@
     font-size: 0.9rem;
     margin: 1em 0;
   }
+}
+span {
+  color: #3372c1;
 }


### PR DESCRIPTION


## Related Issue

Closes #843 
<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
Added the color to text which was not visible in light mode.
<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

## Screenshots

before:
![Screenshot (114)](https://github.com/rohansx/informatician/assets/96622693/9b14c5af-eb66-4300-9c5e-4713225497d9)

after:
![Screenshot (115)](https://github.com/rohansx/informatician/assets/96622693/88f8d23f-13b0-42cf-879f-86407b5eda09)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x ] My code adheres to the established style guidelines of the project.
- [ ] I have included comments in areas that may be difficult to understand.
- [ x] My changes have not introduced any new warnings.
- [x ] I have conducted a self-review of my code.