### PR TITLE
fix: incorrect margin for login with google button on login page 🛠️

### DIFF
--- a/src/pages/Login/Login.jsx
+++ b/src/pages/Login/Login.jsx
@@ -63,7 +63,7 @@ const Login = () => {
       <h2 className=" ml-[140px] w-[650px]  text-center mb-4 mx-auto text-2xl md:text-3xl font-bold text-indigo-600">
       {user ? "Welcome  to Informatician" : "Login to Informatician"}
           </h2>
-      <div  className="ml-[140px] w-[500px]  px-4 py-2 rounded-md text-lg text-center text-white hover:bg-indigo-800 duration-200 ease-out">
+      <div  className="my-0 mx-auto w-[500px] px-4 py-2 rounded-md text-lg text-center text-white hover:bg-indigo-800 duration-200 ease-out">
       <GoogleLogin SetisLoggedIn={SetisLoggedIn} />
       </div>
      


### PR DESCRIPTION
## Close #1080 



## Description
- Fixed the margin bug applied for `Login with Google` button on Login Page.

## Screenshots
<table role="table">
<thead>
<tr>
<th align="center"></th>
<th align="center"></th>
</tr>
</thead>
<tbody>
<tr>
<td align="center"><strong>BEFORE</strong></td>
<td align="center"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/92252895/256084635-827d1d5d-d4ad-406e-8086-7f5af3ed91bd.png"><img src="https://user-images.githubusercontent.com/92252895/256084635-827d1d5d-d4ad-406e-8086-7f5af3ed91bd.png" alt="BEFORE" style="max-width: 100%;"></a></td>
</tr>
<tr>
<td align="center"><strong>AFTER</strong></td>
<td align="center"><a target="_blank" rel="noopener noreferrer" href="https://user-images.githubusercontent.com/92252895/256084617-ab12e29c-ce1e-493a-a590-e18ccf7ee7d9.png"><img src="https://user-images.githubusercontent.com/92252895/256084617-ab12e29c-ce1e-493a-a590-e18ccf7ee7d9.png" alt="AFTER" style="max-width: 100%;"></a></td>
</tr>
</tbody>
</table>


## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.