### PR TITLE
added login alert fixes issue #1082

### DIFF
--- a/components/Upload/Upload.js
+++ b/components/Upload/Upload.js
@@ -3,12 +3,15 @@ import { ToastContainer, toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import axios from "axios";
 import { useParams, useRouter } from "next/navigation";
+import Login from "@/app/login/page";
 
 const FileUploadComponent = () => {
   const [file, setFile] = useState(null);
   const navigate = useRouter();
   const id = useParams();
-
+  // loggedIn variable
+  var loggedIn= true;
+  
   const handleFileChange = (event) => {
     setFile(event.target.files[0]);
   };
@@ -42,7 +45,9 @@ const FileUploadComponent = () => {
   };
 
   return (
-    <div className="p-10 flex flex-col items-center justify-center rounded-lg shadow-lg border">
+    !loggedIn? <ShowLogin/> :
+   ( <div className="p-10 flex flex-col items-center justify-center rounded-lg shadow-lg border">
+     
       <h2 className="text-xl font-bold mb-4">Upload Books</h2>
       <div className="border-2 rounded-lg my-5 p-10 flex flex-col items-center justify-center">
         <input
@@ -82,8 +87,16 @@ const FileUploadComponent = () => {
       </p>
 
       <ToastContainer />
-    </div>
+    </div> )
   );
 };
+
+const ShowLogin=()=>{
+  return(
+    <div className="show-login p-10 flex flex-col items-center justify-center rounded-lg shadow-lg border">
+      <h2 className="text-xl font-bold mb-4">Please first login to upload a book</h2>
+    </div>
+  )
+}
 
 export default FileUploadComponent;


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue number 1082, show warning message to login before uploading books.

Closes #1082 

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
Users can see the upload book option, after filling the entire form while submitting it shows error, authorization failed.
Instead of this, we can show a warning beforehand that you haven't logged in and first you need to login to proceed with adding book.

This pr fixes the issue
<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

## Screenshots

<!-- Add screenshots to preview the changes  -->
![image](https://github.com/rohansx/informatician/assets/68679980/9ae63225-62de-41f8-a006-be35e75bdb6f)


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.