### PR TITLE
feat: made add books form accessible ✨ 

### DIFF
--- a/app/addBooks/page.jsx
+++ b/app/addBooks/page.jsx
@@ -73,38 +73,53 @@ const AddBooks = () => {
             Add Books
           </h1>
           <form className="px-8 py-6 space-y-6 flex flex-col" onSubmit={handleSubmit}>
+            <label for="book-name">Enter the Book Name: </label>
             <input
               className="border border-gray-300 dark:border-gray-700 px-4 py-2 rounded"
               type="text"
+              id="book-name"
+              name="book-name" 
               placeholder="Book Name"
               ref={bookName}
               aria-label="Book Name"
             />
+            <label for="author-name">Enter the Author Name: </label>
             <input
               className="border border-gray-300 dark:border-gray-700 px-4 py-2 rounded"
               type="text"
+              id="author-name"
+              name="author-name" 
               placeholder="Author Name"
               ref={authorName}
               aria-label="Author Name"
             />
+            <label for="publisher-name">Enter the Publisher Name: </label>
             <input
               className="border border-gray-300 dark:border-gray-700 px-4 py-2 rounded"
               type="text"
+              id="publisher-name"
+              name="publisher-name" 
               placeholder="Publisher"
               ref={publisher}
               aria-label="Publisher"
             />
+            <label for="no-of-pages">Enter the Number of Pages: </label>
             <input
               className="border border-gray-300 dark:border-gray-700 px-4 py-2 rounded"
               type="number"
+              id="no-of-pages"
+              name="no-of-pages" 
               min="0"
               placeholder="Pages"
               ref={pages}
               aria-label="Number of Pages"
             />
+            <label for="book-image-url">Enter the Book's Cover Image URL: </label>
             <input
               className="border border-gray-300 dark:border-gray-700 px-4 py-2 rounded"
               type="text"
+              id="book-image-url"
+              name="book-image-url" 
               placeholder="Img Url"
               ref={img}
               aria-label="Image URL"
@@ -121,6 +136,7 @@ const AddBooks = () => {
             <button
               className="bg-blue-500 hover:bg-blue-600 text-white font-bold py-2 px-4 rounded"
               type="submit"
+              role="button"
               aria-label="Add Book"
             >
               Add Book


### PR DESCRIPTION


## Related Issue

Closes #1125

## Description
- Made input elements of Add Books form accessible by adding appropriate `label` elements.
- `label` elements are attached with their necessary input fields by using attributes like `for`, `id` & `name`.
- Overall, this PR is intended to make the entire add books form accessible for screen readers.

## Screenshots
- We can't capture accessibility changes through screenshots as opposed to code changes since accessibility modifications are often imperceptible to the user, as their purpose is to assist disabled individuals.

## Checklist 

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.