### PR TITLE
fix: wrong contributing guidelines documentation link on bug issue template ⚒️ 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -39,7 +39,7 @@ body:
         - label: "I have checked the existing issues"
           required: true
 
-        - label: "I have read the [Contributing Guidelines](https://github.com/rupali-codes/LinksHub/blob/main/CONTRIBUTING.md)"
+        - label: "I have read the [Contributing Guidelines](https://github.com/rohansx/informatician/blob/main/CONTRIBUTING.md)"
           required: true
           
         - label: "I have read the discussion tab thoroughly and got the project idea"


### PR DESCRIPTION
## Related Issue

Closes #1177 

## Description
- Fixed the wrong Contributing Guidelines documentation read link which navigates to `LinksHub` is now solved and navigates to `Informatician`

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.