### PR TITLE
fix: bad contrast color applied for headings on faq page ⚒️

### DIFF
--- a/components/Footer/Footer.css
+++ b/components/Footer/Footer.css
@@ -11,8 +11,7 @@ footer {
     color: rgb(152, 179, 243);
   }
   
-  .footer-div,
-  h2 {
+  footer h2 {
     margin-top: 20px;
     color: rgb(216, 226, 250);
   }


### PR DESCRIPTION
## Related Issue

Closes #1170

## Description
- Fixed the bad contrast color applied for headings on FAQ Page.

## Screenshots
|BEFORE|AFTER|
|:---:|:---:|
| ![](https://user-images.githubusercontent.com/92252895/257397198-3866cbed-92ac-4e66-a96f-d36aa18356be.png) | ![image](https://github.com/rohansx/informatician/assets/92252895/dc69ec70-f4fe-498f-8fee-567e421ceed0) |


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.