### PR TITLE
fix: bad contrast color applied for headings on join page ⚒️✨ 

### DIFF
--- a/components/join/Benefits.jsx
+++ b/components/join/Benefits.jsx
@@ -4,7 +4,7 @@ import {benefitsData} from '@/utils/Constants'
 export default function Benefits() {
     return (
         <section className="text-center mt-10 px-8">
-            <h2 className="mb-11 text-4xl font-bold">BENEFITS</h2>
+            <h2 className="mb-11 text-4xl font-bold text-inherit">BENEFITS</h2>
             {/* Benefits Section */}
             <div className="grid justify-center mx-auto place-items-center gap-20 max-w-5xl grid-cols-1 md:grid-cols-2">
                 {benefitsData.map((benefit) => (
@@ -21,7 +21,7 @@ export default function Benefits() {
                             alt={benefit.imageAlt}
                         />
                         <div>
-                            <h2 className="text-2xl font-bold mt-6 mb-3">{benefit.title}</h2>
+                            <h2 className="text-2xl font-bold mt-6 mb-3 text-inherit">{benefit.title}</h2>
                             <p>{benefit.description}</p>
                         </div>
                     </div>

--- a/components/join/Employee.jsx
+++ b/components/join/Employee.jsx
@@ -6,7 +6,7 @@ export default function Employee() {
     return (
         <section className="my-20 px-8 mx-auto max-w-5xl space-y-20">
             <div className="border p-4 py-12 shadow-md rounded-lg">
-                <h2 className="text-4xl text-center text-blue-300">
+                <h2 className="text-4xl text-center text-blue-500">
                     STRAIGHT FROM <strong> THE SOURCE </strong>
                 </h2>
                 <p className="text-center text-2xl mt-4 text-mono">

--- a/components/join/JobSection.jsx
+++ b/components/join/JobSection.jsx
@@ -21,7 +21,7 @@ export default function JobSection() {
                         className="border dark:border-2 border-gray-300 p-2 rounded-xl shadow-md shadow-slate-800/70 max-w-sm w-full h-full"
                     >
                         <div>
-                            <h2 className="text-xl md:text-2xl font-bold text-center mt-2 mb-2">
+                            <h2 className="text-xl md:text-2xl font-bold text-center mt-2 mb-2 text-inherit">
                                 {position.title}
                             </h2>
                             <p className="text-center mb-2">{position.count} positions</p>


### PR DESCRIPTION
## Related Issue

Closes #1197

## Description
- Fixed bad contrast colors applied for Headings on Join Page.

## Screenshots

https://github.com/rohansx/informatician/assets/92252895/62bc0e07-f2e1-433f-8368-39e68a8215e1

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.