### PR TITLE
fix: bad contrast color for contributors details on team page ⚒️✨ 

### DIFF
--- a/app/team/Contributors.js
+++ b/app/team/Contributors.js
@@ -66,7 +66,7 @@ function Contributors() {
                   />
                 </Link>
                 <div className="my-2 space-y-1">
-                  <h2 className="text-xl font-semibold sm:text-2xl">
+                  <h2 className="text-xl font-semibold sm:text-2xl text-inherit">
                     {contributor.login}
                   </h2>
                   <p className="px-5 text-xs sm:text-base text-gray-400">{`Contributions: ${contributor.contributions}`}</p>

--- a/app/team/Contributors.js
+++ b/app/team/Contributors.js
@@ -69,7 +69,7 @@ function Contributors() {
                   <h2 className="text-xl font-semibold sm:text-2xl text-inherit">
                     {contributor.login}
                   </h2>
-                  <p className="px-5 text-xs sm:text-base text-gray-400">{`Contributions: ${contributor.contributions}`}</p>
+                  <p className="px-5 text-xs sm:text-base text-gray-500">{`Contributions: ${contributor.contributions}`}</p>
                 </div>
                 <div className="flex justify-center pt-2 space-x-4 align-center">
                   {/* Add any additional content or buttons here */}


### PR DESCRIPTION
## Related Issue

Closes #1198

## Description
- Fixed the bad contrast color applied for Contributors details on team page

## Screenshots
|BEFORE|AFTER|
|:---:|:---:|
|![Screen Shot 2023-08-02 at 18 02 16](https://github.com/rohansx/informatician/assets/92252895/32db83aa-96d4-48ef-a100-d8c8d6719fc6)|![Screen Shot 2023-08-02 at 18 01 23](https://github.com/rohansx/informatician/assets/92252895/92709732-563b-4e17-b3a4-eb262a199eff)|


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.