### PR TITLE
fix: incorrect placement of theme toggle button on mobile ⚒️ ✨ 

### DIFF
--- a/components/theme/theme-toggle.jsx
+++ b/components/theme/theme-toggle.jsx
@@ -15,7 +15,7 @@ export function ThemeToggle() {
   
   return (
     <button
-    className="mr-9 inline-flex self-center"
+    className="sm:scale-110 sm:mr-[.90rem] lg:mr-9 inline-flex self-center"
       onClick={() => setTheme(theme === "light" ? "dark" : sysMode === "light" && theme==="system"  ? "dark" : "light")}
     >
       <Icons.sun className="-rotate-90 scale-0 transition-all dark:rotate-0 dark:scale-100" />


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue

Closes #1209 

## Description
- Fixed the incorrect placement of theme toggle button for Mobile devices.

## Screenshots
|BEFORE|AFTER|
|:---:|:---:|
| ![image](https://github.com/rohansx/informatician/assets/92252895/a2208775-c9f1-4c9e-98de-2a5bef937bcf) | ![image](https://github.com/rohansx/informatician/assets/92252895/8d5aa7b4-3f2a-451a-b2e6-ee10d0de1ddf) |


## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.