### PR TITLE
fix: missaligned copyright and it's elements on footer ⚒️✨ 

### DIFF
--- a/components/Footer/Footer.js
+++ b/components/Footer/Footer.js
@@ -60,7 +60,7 @@ const Footer = () => {
               })}
             </div>
           </div>
-          <div className="copyright_footer p-6 mx-6 mt-2">
+          <div className="copyright_footer p-6 mx-6 mt-2 sm:flex-col sm:justify-center sm:items-center sm:gap-5 sm:mt-7 lg:justify-around lg:flex-row">
             <span className={`text-sm font-bold sm:text-center text-blue-500`}>
               © {year}{" "}
               <a href="/" onClick={scrollToTop} className="hover:underline">
@@ -68,7 +68,7 @@ const Footer = () => {
               </a>
               . All Rights Reserved.
             </span>
-            <div className="flex mt-0 space-x-6 sm:justify-center sm:mt-0 mr-14 2xl:mr-0">
+            <div className="flex mt-0 space-x-6 sm:justify-center sm:mt-0 lg:mr-14 2xl:mr-0">
               <Link href="/develop" title="Twitter(External Link)" target="_blank" aria-label="Follow us on Twitter" rel="noopener noreferror">
                 <BsTwitter className="w-6 h-6 transition-all duration-200 ease-in-out transform hover:scale-110 twitter" />
               </Link>


### PR DESCRIPTION
## Related Issue

Closes #1210 

## Description
- Fixed the misaligned copyright container and it's elements properly for mobile devices.
- Used Tailwind's Responsive utility classes like `sm` for mobile devices and `lg` to target tablets and desktops.

## Screenshots
|||
|:---:|:---:|
|![](https://user-images.githubusercontent.com/92252895/257816849-3f9a0beb-2519-4cf5-a483-db3dbe1872c0.png)|![](https://user-images.githubusercontent.com/92252895/257817016-eb12b3f5-d0aa-42e1-ab78-d8ee73c37927.png)|

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.