### PR TITLE
Fixed swiper buttons of popular category not visible in dark mode

### DIFF
--- a/components/BkCards/BkCards.js
+++ b/components/BkCards/BkCards.js
@@ -87,7 +87,7 @@ export default function BkCards(props) {
                 },
               }}
               modules={[Autoplay, Pagination, Navigation]}
-              className="dark:bg-[#161313] h-[30rem]"
+              className="dark:bg-[#151212] h-[30rem]"
             >
               <GhostPrevButton refprop={prevButton} />
               {props.books?.map((book) => {


### PR DESCRIPTION
<!-- Pull Request Template -->

## Related Issue
Fixed swiper buttons of popular category not visible in dark mode

Closes #1221

<!-- If there is no issue number, the PR will not be merged. Therefore, please ensure that the issue number is added -->

## Description
Fixed swiper buttons of popular category not visible in dark mode
<!-- Write a brief description of the changes made in the PR. Explain the problem being addressed, or any relevant
information. -->

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

![258102196-48b3577f-1c05-45a0-a84f-bdfb46aa5f0d](https://github.com/rohansx/informatician/assets/53248489/3cfb6423-b4d4-4b21-a33e-515f3bb8288b)

![bug fixed](https://github.com/rohansx/informatician/assets/53248489/751a9c27-dacb-482c-a626-424150f3087e)

## Checklist 

<!-- [x] - To mark checked, put 'x' in place of ' '(space)  -->
<!-- [ ] - Keep unchecked using ' '(space)  -->

- [x] My code adheres to the established style guidelines of the project.
- [x] I have included comments in areas that may be difficult to understand.
- [x] My changes have not introduced any new warnings.
- [x] I have conducted a self-review of my code.